### PR TITLE
Add checks for ndim

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -990,22 +990,6 @@ pub struct Layout<D: Dimension> {
     pub offset: isize,
 }
 
-/// Asserts that all axes are valid for dimension `D` with `ndim` dimensions
-/// and that none are repeated. (Note that this also implies that the
-/// `axes.len()` is ensured to be <= `ndim`.)
-///
-/// **Panics** if this is not the case.
-pub(crate) fn assert_valid_unique_axes<D: Dimension>(ndim: usize, axes: &[usize]) {
-    let mut usage_counts = D::zeros(ndim);
-    for &axis in axes {
-        assert_eq!(
-            usage_counts[axis], 0,
-            "Each axis must be listed no more than once."
-        );
-        usage_counts[axis] = 1;
-    }
-}
-
 /// Extension methods for `Dimension` types.
 pub(crate) trait DimensionExt {
     /// Applies the fold to the values and returns the result.

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -50,6 +50,8 @@ where
 /// (except for axes of length <= 1, which are positioned as outer axes). This
 /// isn't necessarily the optimal iteration order, but it should be a
 /// reasonable heuristic in most cases.
+///
+/// **Panics** if `axes.for_ndim() != producer.ndim()`.
 pub(crate) fn optimize_any_ord_axes<T, D>(producer: &mut T, axes: &mut AxesFor<T::Dim, D>)
 where
     T: NdReshape + ?Sized,
@@ -59,6 +61,8 @@ where
     // costly) optimizations?
 
     // TODO: specialize for ndim == 3?
+
+    assert_eq!(producer.ndim(), axes.for_ndim());
 
     let num_axes = axes.num_axes();
     if num_axes <= 1 {

--- a/src/pairwise_sum.rs
+++ b/src/pairwise_sum.rs
@@ -91,6 +91,7 @@ impl<'a, S: NdSource, D: Dimension> SourceSubset<'a, S, D> {
     ) -> Self {
         // A few sanity checks.
         if cfg!(debug_assertions) {
+            debug_assert_eq!(source.ndim(), axes.for_ndim());
             for (&ax, &axis_len) in izip!(axes.slice(), axis_lens.slice()) {
                 debug_assert!(axis_len <= source.len_of(Axis(ax)));
                 debug_assert!(axis_len <= std::isize::MAX as usize);


### PR DESCRIPTION
Some of these checks were accidentally removed in #12. It's necessary to check dimensionality even with `AxesFor` due to `IxDyn`.